### PR TITLE
feat(fragment): inherit section classes

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -35,6 +35,7 @@ export default async function decorate(block) {
   if (fragment) {
     const fragmentSection = fragment.querySelector(':scope .section');
     if (fragmentSection) {
+      block.closest('.section').classList.add(...fragmentSection.classList);
       block.closest('.fragment-wrapper').replaceWith(...fragmentSection.childNodes);
     }
   }

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -21,6 +21,7 @@ describe('Fragment block', () => {
     const section = document.querySelector('.section');
     await sectionLoaded(section);
     expect(section.textContent.trim()).to.equal('Hello world!');
+    expect(section.classList.contains('example-container')).to.be.true;
     expect(document.querySelectorAll('.fragment').length).to.equal(1);
   });
 });


### PR DESCRIPTION
For consistent styling of content coming from a fragment, including rules that take section classes into account, we should propagate the fragment's section classes to the target section:

Test URLs:
- Before: https://main--helix-block-collection--adobe.hlx.page/block-collection/fragment
- After: https://fragment-inherit-section-classes--helix-block-collection--adobe.hlx.page/block-collection/fragment
