### PR TITLE
feat: table block

### DIFF
--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -1,0 +1,51 @@
+.table {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table table {
+  width: 100%;
+  max-width: 100%;
+  border-collapse: collapse;
+  font-size: var(--body-font-size-xs);
+}
+
+@media (min-width: 600px) {
+  .table table {
+    font-size: var(--body-font-size-s);
+  }
+}
+
+@media (min-width: 900px) {
+  .table table {
+    font-size: var(--body-font-size-m);
+  }
+}
+
+.table table thead tr {
+  border-top: 2px solid;
+  border-bottom: 2px solid;
+}
+
+.table table tbody tr {
+  border-bottom: 1px solid;
+}
+
+.table table th {
+  font-weight: 700;
+}
+
+.table table th, .table table td {
+  padding: 8px 16px;
+  text-align: left;
+}
+
+/* striped variant */
+.table.striped tbody tr:nth-child(odd) {
+  background-color: var(--overlay-background-color);
+}
+
+/* bordered variant */
+.table.bordered table th, .table.bordered table td {
+  border: 1px solid;
+}

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -1,0 +1,30 @@
+/*
+ * Table Block
+ * Recreate a table
+ * https://www.hlx.live/developer/block-collection/table
+ */
+
+function buildCell(rowIndex) {
+  const cell = rowIndex ? document.createElement('td') : document.createElement('th');
+  if (!rowIndex) cell.setAttribute('scope', 'col');
+  return cell;
+}
+
+export default async function decorate(block) {
+  const table = document.createElement('table');
+  const thead = document.createElement('thead');
+  const tbody = document.createElement('tbody');
+  table.append(thead, tbody);
+  [...block.children].forEach((child, i) => {
+    const row = document.createElement('tr');
+    if (i) tbody.append(row);
+    else thead.append(row);
+    [...child.children].forEach((col) => {
+      const cell = buildCell(i);
+      cell.innerHTML = col.innerHTML;
+      row.append(cell);
+    });
+  });
+  block.innerHTML = '';
+  block.append(table);
+}


### PR DESCRIPTION
VERY basic table block. the first row (after block declaration) becomes the `thead` row with a `col` scope. 6 additional lines of css adds support for two basic variants, striped and bordered. 

after merge of this PR, the test URL below and the documentation on [hlx.live](https://www.hlx.live/developer/block-collection/table) will be published.

Test URLs:
- Before: https://main--helix-block-collection--adobe.hlx.page/block-collection/table
- After: https://table--helix-block-collection--adobe.hlx.page/block-collection/table