### PR TITLE
fix: yt video video empty check

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -25,6 +25,7 @@ const getDefaultEmbed = (url) => `<div style="left: 0; width: 100%; height: 0; p
 const embedYoutube = (url, autoplay) => {
   const usp = new URLSearchParams(url.search);
   const suffix = autoplay ? '&muted=1&autoplay=1' : '';
+  
   let vid = usp.get('v') ? encodeURIComponent(usp.get('v')) : '';
   const embed = url.pathname;
   if (url.origin.includes('youtu.be')) {

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -25,7 +25,7 @@ const getDefaultEmbed = (url) => `<div style="left: 0; width: 100%; height: 0; p
 const embedYoutube = (url, autoplay) => {
   const usp = new URLSearchParams(url.search);
   const suffix = autoplay ? '&muted=1&autoplay=1' : '';
-  let vid = encodeURIComponent(usp.get('v'));
+  let vid = usp.get('v') ? encodeURIComponent(usp.get('v')) : '';
   const embed = url.pathname;
   if (url.origin.includes('youtu.be')) {
     [, vid] = url.pathname.split('/');

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -25,7 +25,6 @@ const getDefaultEmbed = (url) => `<div style="left: 0; width: 100%; height: 0; p
 const embedYoutube = (url, autoplay) => {
   const usp = new URLSearchParams(url.search);
   const suffix = autoplay ? '&muted=1&autoplay=1' : '';
-  
   let vid = usp.get('v') ? encodeURIComponent(usp.get('v')) : '';
   const embed = url.pathname;
   if (url.origin.includes('youtu.be')) {


### PR DESCRIPTION
This was failing before because it was encoding null into null so the conditional when building the embedHTML was wrong

Fix #12 

Test URLs:
- Before: https://main--helix-block-collection--adobe.hlx.page/block-collection/embed
- After: https://fix-video-vid--helix-block-collection--shsteimer.hlx.page/block-collection/embed

I don't think that after url will work yet, need to set this up