### PR TITLE
Vid fix

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -25,6 +25,7 @@ const getDefaultEmbed = (url) => `<div style="left: 0; width: 100%; height: 0; p
 const embedYoutube = (url, autoplay) => {
   const usp = new URLSearchParams(url.search);
   const suffix = autoplay ? '&muted=1&autoplay=1' : '';
+  
   let vid = usp.get('v') ? encodeURIComponent(usp.get('v')) : '';
   const embed = url.pathname;
   if (url.origin.includes('youtu.be')) {

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -25,7 +25,7 @@ const getDefaultEmbed = (url) => `<div style="left: 0; width: 100%; height: 0; p
 const embedYoutube = (url, autoplay) => {
   const usp = new URLSearchParams(url.search);
   const suffix = autoplay ? '&muted=1&autoplay=1' : '';
-  let vid = encodeURIComponent(usp.get('v'));
+  let vid = usp.get('v') ? encodeURIComponent(usp.get('v')) : '';
   const embed = url.pathname;
   if (url.origin.includes('youtu.be')) {
     [, vid] = url.pathname.split('/');

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -25,7 +25,6 @@ const getDefaultEmbed = (url) => `<div style="left: 0; width: 100%; height: 0; p
 const embedYoutube = (url, autoplay) => {
   const usp = new URLSearchParams(url.search);
   const suffix = autoplay ? '&muted=1&autoplay=1' : '';
-  
   let vid = usp.get('v') ? encodeURIComponent(usp.get('v')) : '';
   const embed = url.pathname;
   if (url.origin.includes('youtu.be')) {


### PR DESCRIPTION
This was failing before because it was encoding null into "null" causing the conditional used when building the embedHTML to evaluate incorrectly.

Fix: #12 

Test URLs:

Before: https://main--helix-block-collection--adobe.hlx.page/block-collection/embed
After: https://vid-fix--helix-block-collection--shsteimer.hlx.page/block-collection/embed

FWIW, the above page does not have an example of an embed url of the form that this is intended to fix. If someone can give me access to that gdrive, I'd be happy to create a drafts page to add that example.