### PR TITLE
feat(fragment) - inherit section dataset

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -38,7 +38,13 @@ export default async function decorate(block) {
   if (fragment) {
     const fragmentSection = fragment.querySelector(':scope .section');
     if (fragmentSection) {
-      block.closest('.section').classList.add(...fragmentSection.classList);
+      const mainSection = block.closest('.section');
+      mainSection.classList.add(...fragmentSection.classList);
+      // destination file metadata overrides the fragment metadata in case of conflicts
+      const mergedDataset = { ...fragmentSection.dataset, ...mainSection.dataset };
+      Object.keys(mergedDataset).forEach((key) => {
+        mainSection.dataset[key] = mergedDataset[key];
+      });
       block.closest('.fragment-wrapper').replaceWith(...fragmentSection.childNodes);
     }
   }

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -22,6 +22,8 @@ describe('Fragment block', () => {
     await sectionLoaded(section);
     expect(section.textContent.trim()).to.equal('Hello world!');
     expect(section.classList.contains('example-container')).to.be.true;
+    expect(section.classList.contains('example-style')).to.be.true;
+    expect(section.dataset.exampleData).to.equals('Example Value');
     expect(document.querySelectorAll('.fragment').length).to.equal(1);
   });
 });

--- a/test/blocks/fragment/test.plain.html
+++ b/test/blocks/fragment/test.plain.html
@@ -11,4 +11,14 @@
             </div>
         </div>
     </div>
+    <div class="section-metadata">
+        <div>
+          <div>Style</div>
+          <div>Example Style</div>
+        </div>
+        <div>
+          <div>Example Data</div>
+          <div>Example Value</div>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
Building  on @rofe's https://github.com/adobe/helix-block-collection/pull/4 where the fragment section's classes were propagated to the target section, this PR also propagates the dataset.
In the boilerplate, section metadata:
* styles are added as classes on the fragment section https://github.com/adobe/aem-boilerplate/blob/main/scripts/aem.js#L451-L453 are added as classes and propagated (already done by #4)
* all other keys/values are added in the section's data set https://github.com/adobe/aem-boilerplate/blob/main/scripts/aem.js#L455, and should be propagated (addressed by this PR) 

Test URLs:
Before: https://main--helix-block-collection--adobe.hlx.page/block-collection/fragment
After: https://fragment-inherit-section-classes--helix-block-collection--adobe.hlx.page/block-collection/fragment
