### PR TITLE
chore: use inset instead of top, right, bottom and left

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -26,10 +26,7 @@ main .embed .embed-placeholder > * {
   align-items: center;
   justify-content: center;
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
 }
 
 main .embed .embed-placeholder picture img {


### PR DESCRIPTION
eslint error: Expected shorthand property "inset" (`declaration-block-no-redundant-longhand-properties`)

See https://developer.mozilla.org/en-US/docs/Web/CSS/inset

Test URLs:
- Before: https://main--helix-block-collection--adobe.hlx.page/block-collection/embed
- After: https://inset--helix-block-collection--adobe.hlx.page/block-collection/embed
