### PR TITLE
fix: open nav on hover

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -118,13 +118,36 @@ export default async function decorate(block) {
   if (navSections) {
     navSections.querySelectorAll(':scope .default-content-wrapper > ul > li').forEach((navSection) => {
       if (navSection.querySelector('ul')) navSection.classList.add('nav-drop');
-      navSection.addEventListener('click', () => {
+
+      function closeMenuSection(event) {
+        if (!nav.contains(event.target)) {
+          const expanded = navSection.getAttribute('aria-expanded') === 'true';
+          if (expanded) {
+            navSection.setAttribute('aria-expanded', 'false');
+          }
+        }
+      }
+
+      const openMenu = () => {
         if (isDesktop.matches) {
           const expanded = navSection.getAttribute('aria-expanded') === 'true';
+
           toggleAllNavSections(navSections);
           navSection.setAttribute('aria-expanded', expanded ? 'false' : 'true');
         }
-      });
+      };
+
+      const mouseOverMenu = () => {
+        const expanded = navSection.getAttribute('aria-expanded') === 'true';
+        if (expanded) {
+          return; // it's already open
+        }
+        openMenu();
+      };
+
+      navSection.addEventListener('click', openMenu);
+      navSection.addEventListener('mouseover', mouseOverMenu);
+      document.addEventListener('mouseover', closeMenuSection);
     });
   }
 


### PR DESCRIPTION
Fixes difficult to use sub-menu. User had to click on small arrow to open menu (only if the menuitem is linked).
Not sure if this is the best way. But the current implementation is not good either. 


try to use the first submenu ("Boilerplate Highlights")
Test URLs:
 - before: https://main--helix-block-collection--adobe.hlx.page/block-collection/headings
 - after: https://nav-hover--helix-block-collection--adobe.hlx.page/block-collection/headings
