### PR TITLE
Add support for Youtube and Vimeo to Video block

### DIFF
--- a/blocks/video/video.css
+++ b/blocks/video/video.css
@@ -5,6 +5,11 @@
   margin: 32px auto;
 }
 
+.video.lazy-loading {
+  /* reserve an approximate space to avoid extensive layout shifts */
+  aspect-ratio: 16 / 9;
+}
+
 .video > div {
   display: flex;
   justify-content: center;
@@ -12,6 +17,12 @@
 
 .video video {
   max-width: 100%;
+}
+
+.video video[data-loading] {
+  /* reserve an approximate space to avoid extensive layout shifts */
+  width: 100%;
+  aspect-ratio: 16 / 9;
 }
 
 .video .video-placeholder {

--- a/blocks/video/video.css
+++ b/blocks/video/video.css
@@ -1,3 +1,15 @@
+.video {
+  width: unset;
+  text-align: center;
+  max-width: 800px;
+  margin: 32px auto;
+}
+
+.video > div {
+  display: flex;
+  justify-content: center;
+}
+
 .video video {
   max-width: 100%;
 }
@@ -13,10 +25,7 @@
   align-items: center;
   justify-content: center;
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
 }
 
 .video .video-placeholder picture img {
@@ -37,7 +46,7 @@
   padding: 0;
 }
 
-.video .video-placeholder button::before {
+.video .video-placeholder-play button::before {
   content: "";
   display: block;
   box-sizing: border-box;

--- a/blocks/video/video.js
+++ b/blocks/video/video.js
@@ -82,7 +82,7 @@ export default async function decorate(block) {
     const observer = new IntersectionObserver((entries) => {
       if (entries.some((e) => e.isIntersecting)) {
         observer.disconnect();
-        loadVideoEmbed(block, link);
+        loadVideoEmbed(block, link, false);
       }
     });
     observer.observe(block);

--- a/blocks/video/video.js
+++ b/blocks/video/video.js
@@ -4,7 +4,32 @@
  * https://www.hlx.live/developer/block-collection/video
  */
 
-const getVideoElement = (source, autoplay) => {
+function embedYoutube(url, autoplay) {
+  const usp = new URLSearchParams(url.search);
+  const suffix = autoplay ? '&muted=1&autoplay=1' : '';
+  let vid = usp.get('v') ? encodeURIComponent(usp.get('v')) : '';
+  const embed = url.pathname;
+  if (url.origin.includes('youtu.be')) {
+    [, vid] = url.pathname.split('/');
+  }
+  return `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+      <iframe src="https://www.youtube.com${vid ? `/embed/${vid}?rel=0&v=${vid}${suffix}` : embed}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" 
+      allow="autoplay; fullscreen; picture-in-picture; encrypted-media; accelerometer; gyroscope; picture-in-picture" allowfullscreen="" scrolling="no" title="Content from Youtube" loading="lazy"></iframe>
+    </div>`;
+}
+
+function embedVimeo(url, autoplay) {
+  const [, video] = url.pathname.split('/');
+  const suffix = autoplay ? '?muted=1&autoplay=1' : '';
+  return `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+      <iframe src="https://player.vimeo.com/video/${video}${suffix}" 
+      style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" 
+      frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen  
+      title="Content from Vimeo" loading="lazy"></iframe>
+    </div>`;
+}
+
+function getVideoElement(source, autoplay) {
   const video = document.createElement('video');
   video.setAttribute('controls', '');
   if (autoplay) video.setAttribute('autoplay', '');
@@ -15,25 +40,51 @@ const getVideoElement = (source, autoplay) => {
   video.append(sourceEl);
 
   return video;
+}
+
+const loadVideoEmbed = (block, link, autoplay) => {
+  if (block.dataset.embedIsLoaded) {
+    return;
+  }
+  const url = new URL(link);
+
+  const isYoutube = link.includes('youtube') || link.includes('youtu.be');
+  const isVimeo = link.includes('vimeo');
+  const isMp4 = link.includes('.mp4');
+
+  if (isYoutube) {
+    block.innerHTML = embedYoutube(url, autoplay);
+  } else if (isVimeo) {
+    block.innerHTML = embedVimeo(url, autoplay);
+  } else if (isMp4) {
+    block.textContent = '';
+    block.append(getVideoElement(link, autoplay));
+  }
+
+  block.dataset.embedIsLoaded = true;
 };
 
 export default async function decorate(block) {
-  const a = block.querySelector('a');
-  if (a) {
-    const source = a.href;
-    const pic = block.querySelector('picture');
-    block.innerHTML = '';
-    if (pic) {
-      const wrapper = document.createElement('div');
-      wrapper.className = 'video-placeholder';
-      wrapper.innerHTML = '<div class="video-placeholder-play"><button type="button" title="Play"></button></div>';
-      wrapper.prepend(pic);
-      wrapper.querySelector('.video-placeholder-play button').addEventListener('click', () => {
-        wrapper.replaceWith(getVideoElement(source, true));
-      });
-      block.append(wrapper);
-    } else {
-      block.append(getVideoElement(source, false));
-    }
+  const placeholder = block.querySelector('picture');
+  const link = block.querySelector('a').href;
+  block.textContent = '';
+
+  if (placeholder) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'video-placeholder';
+    wrapper.innerHTML = '<div class="video-placeholder-play"><button type="button" title="Play"></button></div>';
+    wrapper.prepend(placeholder);
+    wrapper.addEventListener('click', () => {
+      loadVideoEmbed(block, link, true);
+    });
+    block.append(wrapper);
+  } else {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) {
+        observer.disconnect();
+        loadVideoEmbed(block, link);
+      }
+    });
+    observer.observe(block);
   }
 }

--- a/blocks/video/video.js
+++ b/blocks/video/video.js
@@ -32,6 +32,8 @@ function embedVimeo(url, autoplay) {
 function getVideoElement(source, autoplay) {
   const video = document.createElement('video');
   video.setAttribute('controls', '');
+  video.dataset.loading = 'true';
+  video.addEventListener('loadedmetadata', () => delete video.dataset.loading);
   if (autoplay) video.setAttribute('autoplay', '');
 
   const sourceEl = document.createElement('source');
@@ -79,10 +81,12 @@ export default async function decorate(block) {
     });
     block.append(wrapper);
   } else {
+    block.classList.add('lazy-loading');
     const observer = new IntersectionObserver((entries) => {
       if (entries.some((e) => e.isIntersecting)) {
         observer.disconnect();
         loadVideoEmbed(block, link, false);
+        block.classList.remove('lazy-loading');
       }
     });
     observer.observe(block);


### PR DESCRIPTION
Fix #32

change: all videos are now centered and have a max-width. 

Test URLs:
- Before: https://main--helix-block-collection--adobe.hlx.page/block-collection/video
- After: https://video--helix-block-collection--adobe.hlx.page/block-collection/video
