### PR TITLE
Prevent background scrolling when a modal is open

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -1,3 +1,7 @@
+body.modal-open {
+  overflow: hidden;
+}
+
 .modal dialog {
   --dialog-border-radius: 16px;
 

--- a/blocks/modal/modal.js
+++ b/blocks/modal/modal.js
@@ -38,7 +38,10 @@ export async function createModal(contentNodes) {
   await loadBlock(block);
   decorateIcons(closeButton);
 
-  dialog.addEventListener('close', () => block.remove());
+  dialog.addEventListener('close', () => {
+    document.body.classList.remove('modal-open');
+    block.remove();
+  });
 
   block.append(dialog);
   return {
@@ -48,6 +51,8 @@ export async function createModal(contentNodes) {
       // Google Chrome restores the scroll position when the dialog is reopened,
       // so we need to reset it.
       setTimeout(() => { dialogContent.scrollTop = 0; }, 0);
+
+      document.body.classList.add('modal-open');
     },
   };
 }


### PR DESCRIPTION


Test URLs:
- Before: https://main--helix-block-collection--adobe.hlx.page/block-collection/modal
- After: https://modal-block-background--helix-block-collection--adobe.hlx.page/block-collection/modal
